### PR TITLE
fix : 장바구니 페이지 - 장바구니 목록 조회 쿼리문 수정

### DIFF
--- a/src/main/java/com/jangbogo/mall/controller/CartController.java
+++ b/src/main/java/com/jangbogo/mall/controller/CartController.java
@@ -35,11 +35,12 @@ public class CartController {
     // 메서드명 : getList
     // 기   능 : 장바구니 목록을 불러온다.
     // 반환타입 : ResponseEntity<List<CartDto>>
-    // 매개변수 : Integer user_idx
+    // 매개변수 : HttpSession session
     // 요청URL : /cart/list?user_idx=1234 GET
     @GetMapping("/cart/list")
-    public ResponseEntity<List<CartDto>> list(Integer user_idx) {                                                       // ResponseEntity<List<CartDto>> -  list값과 상태코드를 함께 반환하기 위한 클래스
-        List<CartDto> list = null;                                                                                      // 변수명 : list - 저장값 : CartDto 저장소 List
+    public ResponseEntity<List<CartDto>> list(HttpSession session) {                                                    // ResponseEntity<List<CartDto>> -  list값과 상태코드를 함께 반환하기 위한 클래스
+        Integer user_idx = (Integer)(session.getAttribute("idx"));                                                      // 변수명 : user_idx - 저장값 : 세션에 저장된 회원번호(idx)
+        List<CartDto> list = null;                                                                                      // 변수명 : list - 저장값 : List<CartDto>
         try {
             list = cartService.getList(user_idx);                                                                        // cartService의 getList메서드에 인자로 회원번호를 지정하여 호출, 반환값을 list에 저장
             return new ResponseEntity<List<CartDto>>(list, HttpStatus.OK);                                              // 성공 시, list와 OK상태코드를 반환 - 상태코드 : 200
@@ -48,6 +49,7 @@ public class CartController {
             return new ResponseEntity<List<CartDto>>(list, HttpStatus.BAD_REQUEST);                                     // 2)list값과 BAD_REQUEST 상태코드 반환  - 상태코드 : 400
         }
     }
+
     // 메서드명 : deleteCartProduct
     // 기   능 : 장바구니에서 선택된 상품을 삭제한다.
     // 반환타입 : ResponseEntity<String>

--- a/src/main/resources/mapper/cartMapper.xml
+++ b/src/main/resources/mapper/cartMapper.xml
@@ -8,10 +8,10 @@
         아이디명 : selectAll
         반환타입 : List<CartDto>
     -->
-    <select id="selectAll" resultType="CartDto">
+    <select id="selectAll" parameterType="Integer" resultType="CartDto">
         SELECT CART.PROD_IDX, CART.USER_IDX, PRODUCT.NAME as prod_name , PRODUCT.PRC as prod_price, PRODUCT.UPLOAD_PATH as upload_path,CART.REG_TM, CART.PROD_CNT as prod_cnt, CART.REG_TM, CART.CRT_TM, CART.UPT_TM, PRODUCT.DC_RATE
-        FROM CART, PRODUCT, USER
-        WHERE CART.PROD_IDX = PRODUCT.IDX AND CART.USER_IDX = USER.IDX
+        FROM CART, PRODUCT
+        WHERE CART.PROD_IDX = PRODUCT.IDX AND CART.USER_IDX = #{user_idx}
         ORDER BY CRT_TM;
     </select>
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 에러 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
[djdu4496/Jangbogo-Mall]origin/djdu_forked -> [djdu4496/Jangbogo-Mall]origin/develop

### 변경 사항
1. 장바구니 페이지 - 전체 목록 조회 시, 계정에 상관 없이 같은 목록이 렌더링되는 에러 수정 -> parameter 사용을 안 했음

### 테스트 결과
이상 없습니다.